### PR TITLE
Fix new annotation's title edit when working in a secondary language.

### DIFF
--- a/source/client/components/CVAnnotationsTask.ts
+++ b/source/client/components/CVAnnotationsTask.ts
@@ -258,7 +258,7 @@ export default class CVAnnotationsTask extends CVTask
     protected createAnnotation(position: number[], direction: number[])
     {
         const languageManager = this.activeDocument.setup.language;
-        const primarySceneLanguage = languageManager.ins.primarySceneLanguage.value;
+        const activeLanguage = languageManager.ins.activeLanguage.value;
 
         const annotations = this.activeAnnotations;
         if (!annotations) {
@@ -275,9 +275,9 @@ export default class CVAnnotationsTask extends CVTask
 
         const model = annotations.getComponent(CVModel2);
         const annotation = new Annotation(template);
-        annotation.language = primarySceneLanguage;
+        annotation.language = activeLanguage;
 
-        annotation.title = languageManager.getLocalizedString("New Annotation");
+        annotation.title = (annotation.title == "Missing content")? languageManager.getLocalizedString("New Annotation") : annotation.title;
         const data = annotation.data;
         data.position = position;
         data.direction = direction;

--- a/source/client/models/Annotation.ts
+++ b/source/client/models/Annotation.ts
@@ -120,10 +120,8 @@ export default class Annotation extends Document<IAnnotation, IAnnotation>
     {
         return {
             id: Document.generateId(),
-            title: "New Annotation",
-            titles: {
-                [DEFAULT_LANGUAGE]: "New Annotation"
-            },
+            title: "",
+            titles: {},
             lead: "",
             leads: {},
             marker: "",


### PR DESCRIPTION
Currently, editing the title of a newly created annotation in a secondary language  actually edit the primary one. 
<img width="828" height="478" alt="image" src="https://github.com/user-attachments/assets/e62751b5-d53c-4bbf-8d49-0f46bc18e9ba" />

Removing default values from the annotation template keeps the behavior coherent across languages. 
Otherwise the default language (`DEFAULT_LANGUAGE`) of the application is always defined with a "New Annotation" value. 

Removing the "New annotation" title from the template also allows to set it in the annotation task according to the language currently used. This also allows one to copy the text of selected annotation in the current language instead of systematically replacing it with "New Annotation" (which was the previous behaviour).