### PR TITLE
Fix the textarea size for articles' source code edition

### DIFF
--- a/source/client/ui/story/styles.scss
+++ b/source/client/ui/story/styles.scss
@@ -589,6 +589,13 @@ $color-component-meta-light: #d9d998;
   }
 }
 
+// Fix the height of the textarea in the source code editor dialog window
+.tox .tox-textarea-wrap {
+  height: 100%;
+  textarea {
+    height: 100%;
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // MISC


### PR DESCRIPTION
Previously:
 

<img width="1913" height="902" alt="Capture d’écran du 2025-07-28 11-52-39" src="https://github.com/user-attachments/assets/1ed00f29-b84d-4832-bcc7-7678b3f0d472" />

Now:
<img width="1913" height="902" alt="image" src="https://github.com/user-attachments/assets/7e39750a-53cb-4f2f-9e66-310ac168870e" />
