### PR TITLE
Fix scene loading detection with LOD-enabled derivative streaming

### DIFF
--- a/source/client/components/CVViewer.ts
+++ b/source/client/components/CVViewer.ts
@@ -44,7 +44,7 @@ export default class CVViewer extends Component
 
     private _rootElement: HTMLElement = null;
     private _needsAnnoFocus: boolean = false;
-    private _modelLoadCount: number = 0;
+    private _loadedModels = new Set<CVModel2>();
 
     protected static readonly ins = {
         annotationsVisible: types.Boolean("Annotations.Visible"),
@@ -461,16 +461,30 @@ export default class CVViewer extends Component
         });
         this.ins.variant.setOptions([...variantSet]);
 
-        // if all models in scene have loaded derivatives closest to scene quality
-        // (or greater than Thumb with LOD enabled), consider scene fully loaded.
-        if(this.assetManager.outs.initialLoad.value && 
-            (this.getGraphComponent(CVSetup).derivatives.ins.enabled.value && event.quality > EDerivativeQuality.Thumb
-            || event.quality === event.model.derivatives.select(EDerivativeUsage.Web3D, this.ins.quality.value).data.quality)) {
-            if(++this._modelLoadCount === models.length) {
-                this.analytics.sendProperty("Loading_Time", this.analytics.getTimerTime()/1000);
-                this.analytics.resetTimer();
-                this.assetManager.outs.initialLoad.setValue(false);
-                this.outs.sceneLoaded.setValue(true);
+        // Track initial scene loading so the spinner is only shown once, during the initial load.
+        // A model counts as loaded when it has loaded the derivative it currently requests:
+        //  - with LOD enabled, that is the quality picked by the derivatives controller for the
+        //    initial view (which may legitimately stay at Thumb for small/distant models),
+        //  - otherwise it is the scene quality.
+        // We track loaded models in a Set (once each) rather than counting model-load events:
+        // with LOD, a single model streams several qualities and some models never load above
+        // Thumb, so an event counter never reliably reaches models.length. That left initialLoad
+        // stuck at true and made the spinner reappear on every subsequent LOD quality load.
+        if(this.assetManager.outs.initialLoad.value) {
+            const lodEnabled = this.getGraphComponent(CVSetup).derivatives.ins.enabled.value;
+            const requestedQuality = lodEnabled
+                ? event.model.ins.quality.value
+                : event.model.derivatives.select(EDerivativeUsage.Web3D, this.ins.quality.value).data.quality;
+
+            if(event.quality === requestedQuality) {
+                this._loadedModels.add(event.model);
+
+                if(models.every(model => this._loadedModels.has(model))) {
+                    this.analytics.sendProperty("Loading_Time", this.analytics.getTimerTime()/1000);
+                    this.analytics.resetTimer();
+                    this.assetManager.outs.initialLoad.setValue(false);
+                    this.outs.sceneLoaded.setValue(true);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixed a bug where the initial scene loading spinner would reappear during subsequent derivative quality loads when LOD (Level of Detail) is enabled. The issue was caused by unreliable model load event counting when models stream multiple derivative qualities.

## Key Changes
- Replaced `_modelLoadCount` counter with `_loadedModels` Set to track which models have loaded their requested derivatives
- Updated loading completion logic to check if all models have loaded their currently-requested quality level, rather than counting load events
- Improved handling of LOD-enabled scenarios where:
  - Models stream multiple quality levels over time
  - Some models legitimately stay at Thumb quality for small/distant objects
  - A simple event counter never reliably reaches `models.length`
- Added comprehensive comments explaining the loading detection strategy and why the Set-based approach is necessary

## Implementation Details
- With LOD enabled, a model's "requested quality" is determined by `event.model.ins.quality.value` (set by the derivatives controller)
- Without LOD, the requested quality is the scene's configured quality level
- A model is considered loaded once it delivers a derivative matching its requested quality
- Scene is marked fully loaded only when all models have loaded their respective requested qualities
- This prevents the spinner from reappearing when LOD causes subsequent quality upgrades to load

https://claude.ai/code/session_01QXDXYXAg7sCvzMLRPeh9D2